### PR TITLE
Conditionally render JSONP

### DIFF
--- a/rest_framework_jsonp/renderers.py
+++ b/rest_framework_jsonp/renderers.py
@@ -14,7 +14,7 @@ class JSONPRenderer(JSONRenderer):
     wrapping the json output in a callback function.
     """
 
-    media_type = 'application/javascript'
+    js_media_type = 'application/javascript'
     format = 'jsonp'
     callback_parameter = 'callback'
     default_callback = 'callback'
@@ -24,9 +24,10 @@ class JSONPRenderer(JSONRenderer):
         """
         Determine the name of the callback to wrap around the json output.
         """
-        request = renderer_context.get('request', None)
+        request = renderer_context.get('request')
         params = request and get_query_params(request) or {}
-        return params.get(self.callback_parameter, self.default_callback)
+        return (params[self.callback_parameter] or self.default_callback
+                if self.callback_parameter in params else None)
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """
@@ -39,4 +40,6 @@ class JSONPRenderer(JSONRenderer):
         callback = self.get_callback(renderer_context)
         json = super(JSONPRenderer, self).render(data, accepted_media_type,
                                                  renderer_context)
-        return callback.encode(self.charset) + b'(' + json + b');'
+        if accepted_media_type == self.js_media_type or callback is not None:
+            json = callback.encode(self.charset) + b'(' + json + b');'
+        return json


### PR DESCRIPTION
Here's my attempt to fix #3.

#### Pros
- This allows you to use a JSON endpoint normally
- This complies with the expected JSONP behavior that wraps your JSON when a `callback` parameter is provided (and defaults to `'callback'` when no value is specified) or `application/javascript` is used
- No custom code needed in your view function

#### Cons
- The `media_type` is now set to `application/json` from `JSONRenderer` (and therefore, if `callback` is provided without explicitly requesting the proper `application/javascript` content type, it will respond with `application/json`)

There's [another solution from the docs](http://www.django-rest-framework.org/api-guide/renderers/#varying-behaviour-by-media-type) that demonstrates how to use multiple renderers (based on accepted media type). That method would allow you to use `application/javascript` again to eliminate the above con, but if you're manually doing that, you may as well manually wrap your json too without this plugin. Because you want to cut down on verbosity, the pros may outweigh the con.

Also, Chrome didn't complain when I tried `<script src="myendpoint?callback=mycallback">`. And jQuery uses the right media type when using JSONP, so no issue there.

Thoughts?
